### PR TITLE
Force drawer position update on window resize

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -353,6 +353,12 @@ angular.module('google.places', [])
                     event.preventDefault();  // prevent blur event from firing when clicking selection
                 });
 
+                $window.onresize = function () {
+                    $scope.$apply(function () {
+                        $scope.position = getDrawerPosition($scope.input);
+                    });
+                }
+
                 $scope.isOpen = function () {
                     return $scope.predictions.length > 0;
                 };


### PR DESCRIPTION
Right now if you resize the window the drawer only updates when you start typing again. This PR listens for window resizing so that the drawer sticks to the input.