### PR TITLE
Fix tests not passing:

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -38,7 +38,7 @@ module.exports = function (grunt) {
         singleRun: true
       },
       dev: {
-        browsers: ['PhantomJS'],
+        browsers: ['Chrome'],
         reporters: ['mocha'],
         autoWatch: true,
         singleRun: false

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -5,6 +5,7 @@ module.exports = function(config) {
     files: [
       'bower_components/angular/angular.js',
       'bower_components/angular-mocks/angular-mocks.js',
+      'https://maps.googleapis.com/maps/api/js?libraries=places', 
       'src/**/*.js',
       'spec/**/*.js'
     ],

--- a/spec/autocomplete_spec.js
+++ b/spec/autocomplete_spec.js
@@ -198,8 +198,9 @@ describe('Directive: gPlacesAutocomplete', function () {
         compileAndDigest('<input type="text" g-places-autocomplete ng-model="place" />');
     }));
 
-    // TODO: write more tests!
     it('should initialize model', function () {
+        expect(google).toBeDefined();
+        expect($isolatedScope.model).toBeDefined();
     });
 });
 


### PR DESCRIPTION
```
modified:   Gruntfile.js -- Change `karma:dev` to use Chrome to allow for easy debugging of tests
modified:   karma.conf.js -- Add reference to Google Places API to stop dependent tests from breaking
modified:   spec/autocomplete_spec.js -- Add test for whether the model is defined
```
