### PR TITLE
Fix $apply overflow on backspace

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -189,7 +189,7 @@ angular.module('google.places', [])
 
                         request = angular.extend({ input: viewValue }, $scope.options);
                         autocompleteService.getPlacePredictions(request, function (predictions, status) {
-                            $scope.$apply(function () {
+                            $timeout(function () {
                                 var customPlacePredictions;
 
                                 clearPredictions();


### PR DESCRIPTION
Add timeout to place predictions to avoid overflowing the $apply function on using backspace