### PR TITLE
Google Logo URL update

### DIFF
--- a/src/autocomplete.css
+++ b/src/autocomplete.css
@@ -23,14 +23,14 @@
     height: 16px;
     text-align: right;
     display: block;
-    background-image: url(//maps.gstatic.com/mapfiles/api-3/images/powered-by-google-on-white2.png);
+    background-image: url(//maps.gstatic.com/mapfiles/api-3/images/powered-by-google-on-white3.png);
     background-position: right;
     background-repeat: no-repeat;
     background-size: 104px 16px
 }
 
 .hdpi.pac-container:after {
-    background-image: url(//maps.gstatic.com/mapfiles/api-3/images/powered-by-google-on-white2_hdpi.png)
+    background-image: url(//maps.gstatic.com/mapfiles/api-3/images/powered-by-google-on-white3_hdpi.png)
 }
 
 .pac-item {


### PR DESCRIPTION
Changed Logo URL to Version 3: https://developers.google.com/places/web-service/policies

Fix for issue #81 