### PR TITLE
to address google javascript api internal issue number 33733036:

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -164,7 +164,7 @@ angular.module('google.places', [])
                                 });
                             });
                         } else {
-                            placesService.getDetails({ placeId: prediction.place_id }, function (place, status) {
+                            placesService.getDetails({ reference: prediction.reference }, function (place, status) {
                                 if (status == google.maps.places.PlacesServiceStatus.OK) {
                                     $scope.$apply(function () {
                                         $scope.model = place;


### PR DESCRIPTION
" some Place IDs are being replaced with newer ones, but Autocomplete is
not serving the new Place IDs yet. Our engineering team is looking into
the issue with a high priority. "

the resolution is to submit the getDetails message using 'reference'
instead of 'placeId' for the lookup.