### PR TITLE
Correcting dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,13 +5,12 @@
     "type": "git",
     "url": "http://github.com/kuhnza/angular-google-places-autocomplete.git"
   },
-  "dependencies": {
-    "grunt-contrib-cssmin": "^0.10.0"
-  },
+  "dependencies": { },
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-bower-task": "^0.4.0",
     "grunt-contrib-clean": "^0.5.0",
+    "grunt-contrib-cssmin": "^0.10.0",
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-contrib-uglify": "~0.4.0",
     "grunt-karma": "~0.11.0",


### PR DESCRIPTION
Moving `grunt-contrib-cssmin` as a dev dependency.

This change is required to avoid npm warning (`UNMET PEER DEPENDENCY grunt`) In projects that do not use grunt.