### PR TITLE
allow access to selected prediction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-google-places-autocomplete",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "repository": {
     "type": "git",
     "url": "http://github.com/kuhnza/angular-google-places-autocomplete.git"

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -168,6 +168,7 @@ angular.module('google.places', [])
                                 if (status == google.maps.places.PlacesServiceStatus.OK) {
                                     $scope.$apply(function () {
                                         $scope.model = place;
+                                        $scope.model.selection = prediction;
                                         $scope.$emit('g-places-autocomplete:select', place);
                                         $timeout(function () {
                                             controller.$viewChangeListeners.forEach(function (fn) { fn(); });


### PR DESCRIPTION
@kuhnza 

- for certain google places the info packet returned contains differentiated or missing information, which leads to invalid address (typically missing street names).
Passing the selected Place allows access to this information that can then be added to the final object in cases where forms require these fields/values to be complete.
