### PR TITLE
custome css inside autocomplete options

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -81,7 +81,8 @@ angular.module('google.places', [])
                             query: 'query',
                             predictions: 'predictions',
                             active: 'active',
-                            selected: 'selected'
+                            selected: 'selected',
+                            class:$scope.options.classes || ''
                         });
 
                         $drawer = $compile(drawerElement)($scope);


### PR DESCRIPTION
In cases where you have multiple autocomplete dropdown, if you need to customise css for a particular dropdown, you can add a class in the autocomplete options for dropdown.